### PR TITLE
Fix: module names not resolving due to space

### DIFF
--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -15,7 +15,7 @@ var urlMatch = function(url, lookup) {
 };
 
 var stripQuotes = function(jqElement) {
-  return jqElement.text().replace(/"|'/g, '');
+  return jqElement.text().replace(/"|'/g, '').trim();
 };
 
 var showLoader = function($) {


### PR DESCRIPTION
Issue: Try to use Github-linker here in this file, 

https://github.com/namshi/roger/blob/master/src/client/components/buildHistory.jsx

Clicking on `react` leads to   https://www.npmjs.com/package/%20react  because of the extra space.
